### PR TITLE
return promise from template-registry-entry

### DIFF
--- a/src/fuse-aurelia-loader.js
+++ b/src/fuse-aurelia-loader.js
@@ -52,7 +52,7 @@ export class FuseAureliaLoader extends Loader {
       'fetch': function(address) {
         console.log('fetch =>', address)
         let entry = that.getOrCreateTemplateRegistryEntry(address);
-        return entry.templateIsLoaded ? entry : that.templateLoader.loadTemplate(that, entry).then(x => entry);
+        return entry.templateIsLoaded ? Promise.resolve(entry) : that.templateLoader.loadTemplate(that, entry).then(x => entry);
       }
     });
     // this.addPlugin('html-resource-plugin', {


### PR DESCRIPTION
Hi @leon-andria,

first of all, thanks for fuse-aurelia-loader. 👍 
I've followed the fuse-box issue about Aurelia integration and I thought why not give this a try. 😃 

This change makes `hello-world.html` resolve correctly. It's a small (and maybe even obvious) change but I've tried to debug why `<hello-world>` wouldn't load and noticed that `ViewEngine.loadViewFactory` expects a promise.